### PR TITLE
feat: rofiles-fuse support mknod

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ostree (2024.6-1deepin6) unstable; urgency=medium
+
+  * rofiles-fuse support mknod. 
+
+ -- xiamengliang <xiamengliang@uniontech.com>  Thu, 05 Dec 2024 17:34:45 +0800
+
 ostree (2024.6-1deepin5) unstable; urgency=medium
 
   * fix: ensure update boot configuration for each deployment.

--- a/debian/patches/deepin-rofiles-fuse-support-mknod.patch
+++ b/debian/patches/deepin-rofiles-fuse-support-mknod.patch
@@ -1,0 +1,14 @@
+--- a/src/rofiles-fuse/main.c
++++ b/src/rofiles-fuse/main.c
+@@ -154,7 +154,10 @@
+ static int
+ callback_mknod (const char *path, mode_t mode, dev_t rdev)
+ {
+-  return -EROFS;
++  path = ENSURE_RELPATH (path);
++  if (mknodat (basefd, path, mode, rdev) == -1)
++    return -errno;
++  return 0;
+ }
+ 
+ static int

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ deepin-deploy-when-root-is-overlay.patch
 make-socket-callback-during-cleanup-into.patch
 deepin-save-last-boot-as-defalt-for-grub.patch
 deepin-use-custom-grub-message.patch
+deepin-rofiles-fuse-support-mknod.patch


### PR DESCRIPTION
rofiles-fuse support mknod

testcase:
```
$mkdir a b
$ sudo rofiles-fuse a b
$ sudo mknod b/test-char c 0 0
$ sudo ls -al b/test-char
crw-r--r-- 1 root root 0, 0 Dec  5 17:49 b/test-char
```